### PR TITLE
Layout text along arc

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,12 @@
 
 <label>bezier accuracy <span title="0.5 = accurate to half a pixel &#013;.001 = accurate to 1/1000th of a pixel &#013;smaller numbers take longer to compute &#013;leave blank for auto">&#128712;</span> : <input type="text" id="input-bezier-accuracy" placeholder="auto" /></label>
 
+<label>arc radius: <input type="number" id="input-arc-radius" value="100" /></label>
+
+<label>arc start angle: <input type="number" id="input-arc-start-angle" value="45" /></label>
+
+<label>arc end angle: <input type="number" id="input-arc-end-angle" value="135" /></label>
+
 <div id="svg-render"></div>
 
 <textarea id="output-svg"></textarea>

--- a/index.js
+++ b/index.js
@@ -8,7 +8,22 @@ var App = /** @class */ (function () {
                 size = parseFloat(_this.sizeInput.value);
             if (!size)
                 size = 100;
-            _this.render(_this.selectFamily.selectedIndex, _this.selectVariant.selectedIndex, _this.textInput.value, size, _this.unionCheckbox.checked, _this.separateCheckbox.checked, parseFloat(_this.bezierAccuracy.value) || undefined);
+            var arcRadius = _this.arcRadiusInput.valueAsNumber;
+            if (!arcRadius)
+                arcRadius = parseFloat(_this.arcRadiusInput.value);
+            if (!arcRadius)
+                size = 100;
+            var arcStartAngle = _this.arcStartAngleInput.valueAsNumber;
+            if (!arcStartAngle)
+                arcStartAngle = parseFloat(_this.arcStartAngleInput.value);
+            if (!arcStartAngle)
+                size = 45;
+            var arcEndAngle = _this.arcEndAngleInput.valueAsNumber;
+            if (!arcEndAngle)
+                arcEndAngle = parseFloat(_this.arcEndAngleInput.value);
+            if (!arcEndAngle)
+                size = 135;
+            _this.render(_this.selectFamily.selectedIndex, _this.selectVariant.selectedIndex, _this.textInput.value, size, _this.unionCheckbox.checked, _this.separateCheckbox.checked, parseFloat(_this.bezierAccuracy.value) || undefined, arcRadius, arcStartAngle, arcEndAngle);
         };
         this.loadVariants = function () {
             _this.selectVariant.options.length = 0;
@@ -25,12 +40,15 @@ var App = /** @class */ (function () {
         this.textInput = this.$('#input-text');
         this.bezierAccuracy = this.$('#input-bezier-accuracy');
         this.sizeInput = this.$('#input-size');
+        this.arcRadiusInput = this.$('#input-arc-radius');
+        this.arcStartAngleInput = this.$('#input-arc-start-angle');
+        this.arcEndAngleInput = this.$('#input-arc-end-angle');
         this.renderDiv = this.$('#svg-render');
         this.outputTextarea = this.$('#output-svg');
     };
     App.prototype.handleEvents = function () {
         this.selectFamily.onchange = this.loadVariants;
-        this.selectVariant.onchange = this.textInput.onchange = this.textInput.onkeyup = this.sizeInput.onchange = this.unionCheckbox.onchange = this.separateCheckbox.onchange = this.bezierAccuracy.onchange = this.renderCurrent;
+        this.selectVariant.onchange = this.textInput.onchange = this.textInput.onkeyup = this.sizeInput.onchange = this.unionCheckbox.onchange = this.separateCheckbox.onchange = this.bezierAccuracy.onchange = this.arcRadiusInput.onchange = this.arcStartAngleInput.onchange = this.arcEndAngleInput.onchange = this.renderCurrent;
     };
     App.prototype.$ = function (selector) {
         return document.querySelector(selector);
@@ -52,7 +70,7 @@ var App = /** @class */ (function () {
         };
         xhr.send();
     };
-    App.prototype.render = function (fontIndex, variantIndex, text, size, union, separate, bezierAccuracy) {
+    App.prototype.render = function (fontIndex, variantIndex, text, size, union, separate, bezierAccuracy, arcRadius, arcStartAngle, arcEndAngle) {
         var _this = this;
         var f = this.fontList.items[fontIndex];
         var v = f.variants[variantIndex];
@@ -60,6 +78,8 @@ var App = /** @class */ (function () {
         opentype.load(url, function (err, font) {
             //generate the text using a font
             var textModel = new makerjs.models.Text(font, text, size, union, false, bezierAccuracy);
+            var arc = new makerjs.paths.Arc([0, 0], arcRadius, arcStartAngle, arcEndAngle);
+            makerjs.layout.childrenOnPath(textModel, arc, 0, true);
             if (separate) {
                 for (var i in textModel.models) {
                     textModel.models[i].layer = i;


### PR DESCRIPTION
This adds three numeric input fields to the form (arc radius, arc start angle & arc end angle) and lays the text out along the arc in a clockwise direction. I created the PNG below from the SVG output with the font set to Alpha Slab One, a font size of 20, an arc radius of 200 and arc angle 45-135.

![sample](https://user-images.githubusercontent.com/3169/65791769-4dcb8300-e15a-11e9-952f-24ef4e97484b.png)



